### PR TITLE
Linux 5.15.x ion: add vmap and vunmap ops

### DIFF
--- a/ion/ion_heap.c
+++ b/ion/ion_heap.c
@@ -106,12 +106,14 @@ int ion_heap_map_user(struct ion_heap *heap, struct ion_buffer *buffer,
 
 static int ion_heap_clear_pages(struct page **pages, int num, pgprot_t pgprot)
 {
-	void *addr = vm_map_ram(pages, num, -1);
-
+	//void *addr = vm_map_ram(pages, num, -1);
+	void *addr = vmap(pages, num, VM_MAP, pgprot);
+	
 	if (!addr)
 		return -ENOMEM;
 	memset(addr, 0, PAGE_SIZE * num);
-	vm_unmap_ram(addr, num);
+	//vm_unmap_ram(addr, num);
+	vunmap(addr);
 
 	return 0;
 }


### PR DESCRIPTION
Pull request https://github.com/PaserTech-Hardware/cedar/pull/3 is verified on 5.15.x, not 6.2.x.
